### PR TITLE
Use "$args" instead of deprecated "*" in `cmd`

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -19,7 +19,7 @@ class Djlint(PythonLinter):
 
     """
 
-    cmd = "djlint ${temp_file} *"
+    cmd = "djlint ${temp_file} ${args}"
     defaults = {
         "selector": "text.html, text.html.django, text.html.jinja2, text.html.njk, text.html.handlebars",
         "--ignore=,": "",


### PR DESCRIPTION
Actually, an `*` in `cmd` should already print a deprecation warning (iirc) in Sublime's console.  The "new"
explicit name for this marker is `${args}`.  

